### PR TITLE
Avoid ZeroDivisionError when data are missing

### DIFF
--- a/FieldClimate/Utils.py
+++ b/FieldClimate/Utils.py
@@ -37,6 +37,9 @@ def get_station_data_date(user, password, station_name, date=datetime.now()):
         if temp_sensor is None or temp_sensor.get_status() is False:
             temp_sensor = station.get_sensor('HC Air temperature')
         temp_precip = station.get_sensors_measures([temp_sensor, precip_sensor])
+        if not temp_precip:
+            print "Missing data!"
+            return None
         date_data = {'precipitation': get_sensor_sum(precip_sensor, temp_precip),
                      'temperature': {'aver': get_sensor_average(temp_sensor, temp_precip),
                                      'min': get_sensor_min(temp_sensor, temp_precip),


### PR DESCRIPTION
When empty list is returned, `get_sensor_average` return an error:

``` shell
 File "FieldClimate/Utils.py", line 41, in get_station_data_date
    'temperature': {'aver': get_sensor_average(temp_sensor, temp_precip),
  File "FieldClimate/Utils.py", line 62, in get_sensor_average
    return round(get_sensor_sum(sensor_name, measures, mode)/ len(measures), 4)
ZeroDivisionError: float division by zero
```
