### PR TITLE
added FieldClimateRestAPI.get_station_config()

### DIFF
--- a/FieldClimate/RestAPI.py
+++ b/FieldClimate/RestAPI.py
@@ -76,6 +76,12 @@ class FieldClimateRestAPI(RestAPI):
             if station['f_name'] == station_name:
                 return station
 
+    def get_station_config(self, station_name):
+        params = self.auth_params({
+            'station_name': station_name
+        })
+        return self.call_api_method('CIDIStationConfig2/Get', params)['ReturnDataSet'][0]
+
     def get_station_data_last(self, station_name, rows=None, group=None, show_user_units=False):
         params = self.auth_params({
             'station_name': station_name,

--- a/FieldClimate/Utils.py
+++ b/FieldClimate/Utils.py
@@ -45,7 +45,7 @@ def get_station_data_date(user, password, station_name, date=datetime.now()):
             temp_sensor = station.get_sensor('HC Air temperature')
         temp_precip = station.get_sensors_measures([temp_sensor, precip_sensor])
         if not temp_precip:
-            print "Missing data!"
+            print("Missing data!")
             return None
         date_data = {'precipitation': get_sensor_sum(precip_sensor, temp_precip),
                      'temperature': {'aver': get_sensor_average(temp_sensor, temp_precip),


### PR DESCRIPTION
`get_station_config` corresponds to the API's `CIDIStationConfig2/Get` method, which provides a little bit more information than the data given by `CIDIStationList`.

Also fixes a previous commit's python-2 print statement.