### PR TITLE
Officially drop support for Python < 3.5 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ By now, the repository is not available at pip but still, you can easily install
 
 ## Requirements
 
-Python 2.7.9+ and 3.4.3+ should be compatible. Python 2 users need to install `enum34` from pypi.
+Python versions 3.5 and higher are supported.
 
 ## Usage
 


### PR DESCRIPTION
Some of my previous contributions to this repo have targeted broad version support for Python 2.7 and 3. This was because I was working with 2.7 myself in the agrimgt codebase. Since those commits, I've dropped support for python 2 internally at agrimgt. I also see that @kstopa referenced python3 in commit 5e508c9.

Therefore, would now be a good time to explicitly agree to drop some older python versions? Doing this will allow for a lot of cleanup and ease future development.

I chose 3.5 as a minimum version because [this is the lowest version Django currently supports](https://docs.djangoproject.com/en/2.1/faq/install/#what-python-version-can-i-use-with-django), and it's the version that comes in [the current debian stable branch](https://packages.debian.org/stretch/python3).